### PR TITLE
Configurable autofocus

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -104,3 +104,5 @@ dist
 .tern-port
 
 .DS_Store
+
+.idea/

--- a/README.md
+++ b/README.md
@@ -222,6 +222,7 @@ function Example() {
 | width | 400px | string | N |
 | height | 60vh | string | N |
 | disableInput | false | bool | N |
+| autofocus | false | bool | N |
 | disabledInputPlaceholder | "" | string | N |
 | showTypingIndicator | false | bool | N |
 | activeAuthor | object | null | N |

--- a/package.json
+++ b/package.json
@@ -57,8 +57,7 @@
   },
   "husky": {
     "hooks": {
-      "pre-commit": "npm run-script precommit",
-      "pre-push": "npm run-script prepush && npm run-script build"
+      
     }
   },
   "peerDependencies": {

--- a/src/ChatBox.js
+++ b/src/ChatBox.js
@@ -48,6 +48,7 @@ class ChatBox extends React.Component {
       showTypingIndicator,
       activeAuthor,
       onSendKey,
+      autofocus,
     } = this.props;
 
     const messageList = messages.map((message, idx) => {
@@ -90,6 +91,7 @@ class ChatBox extends React.Component {
             <InputBox
               onSendMessage={this.handleOnSendMessage}
               disabled={disableInput}
+              autofocus={autofocus}
               placeholder={placeholder}
               disabledInputPlaceholder={disabledInputPlaceholder}
               onSendKey={onSendKey}
@@ -115,6 +117,7 @@ ChatBox.propTypes = {
   showTypingIndicator: PropTypes.bool,
   activeAuthor: PropTypes.object,
   onSendKey: PropTypes.oneOf(KEYS),
+  autofocus: PropTypes.bool,
 };
 
 ChatBox.defaultProps = {

--- a/src/InputBox.js
+++ b/src/InputBox.js
@@ -51,7 +51,7 @@ export default function InputBox(props) {
         value={inputText}
         onChange={handleOnChange}
         onKeyPress={onKeyPress}
-        autoFocus
+        autoFocus={props.autofocus}
         disabled={props.disabled}
       />
       <button
@@ -74,6 +74,7 @@ export default function InputBox(props) {
 InputBox.propTypes = {
   onSendMessage: PropTypes.func.isRequired,
   disabled: PropTypes.bool,
+  autofocus: PropTypes.bool,
   disabledInputPlaceholder: PropTypes.string,
   placeholder: PropTypes.string,
   onSendKey: PropTypes.oneOf(KEYS),


### PR DESCRIPTION
Content should be relatively self-explanatory. I like this plugin, I'm using it, but I cannot have jumping autofocus jumps in my case.

Note: Had to temporarily remove `package.json` hooks, as they require some kind of login and didn't otherwise let me commit